### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,11 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath)) {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Fixes [https://github.com/pandey-mithun/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/pandey-mithun/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This involves:

1. Using `Path.GetFullPath` to resolve any directory traversal elements in the combined path.
2. Using `Path.GetFullPath` on the destination directory to get its fully resolved path.
3. Validating that the resolved output path starts with the resolved destination directory path, and aborting if this is not true.

This ensures that any attempt to write files outside the intended directory is caught and prevented.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
